### PR TITLE
Add Gtk.Video and Gtk.MediaControls

### DIFF
--- a/lib/src/main/kotlin/io/github/compose4gtk/gtk/components/MediaControls.kt
+++ b/lib/src/main/kotlin/io/github/compose4gtk/gtk/components/MediaControls.kt
@@ -1,0 +1,34 @@
+package io.github.compose4gtk.gtk.components
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ComposeNode
+import io.github.compose4gtk.GtkApplier
+import io.github.compose4gtk.GtkComposeWidget
+import io.github.compose4gtk.LeafComposeNode
+import io.github.compose4gtk.modifier.Modifier
+import org.gnome.gtk.MediaStream
+import org.gnome.gtk.MediaControls as GtkMediaControls
+
+/**
+ * Creates a [org.gnome.gtk.MediaControls] that controls a [MediaStream].
+ *
+ * @param state The [VideoState] that controls the video's media stream.
+ * @param modifier Compose [Modifier] for layout and styling.
+ */
+@Composable
+fun MediaControls(
+    state: VideoState,
+    modifier: Modifier = Modifier,
+) {
+    ComposeNode<GtkComposeWidget<GtkMediaControls>, GtkApplier>(
+        factory = {
+            LeafComposeNode(GtkMediaControls())
+        },
+        update = {
+            set(state.video?.mediaStream) { mediaStream: MediaStream? ->
+                this.widget.mediaStream = mediaStream
+            }
+            set(modifier) { applyModifier(it) }
+        },
+    )
+}

--- a/lib/src/main/kotlin/io/github/compose4gtk/gtk/components/Video.kt
+++ b/lib/src/main/kotlin/io/github/compose4gtk/gtk/components/Video.kt
@@ -1,0 +1,33 @@
+package io.github.compose4gtk.gtk.components
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ComposeNode
+import io.github.compose4gtk.GtkApplier
+import io.github.compose4gtk.GtkComposeWidget
+import io.github.compose4gtk.LeafComposeNode
+import io.github.compose4gtk.modifier.Modifier
+import org.gnome.gio.File
+import org.gnome.gtk.GraphicsOffloadEnabled
+import org.gnome.gtk.Video as GtkVideo
+
+@Composable
+fun Video(
+    modifier: Modifier = Modifier,
+    file: File? = null,
+    autoplay: Boolean = false,
+    graphicsOffload: GraphicsOffloadEnabled = GraphicsOffloadEnabled.DISABLED,
+    loop: Boolean = false,
+) {
+    ComposeNode<GtkComposeWidget<GtkVideo>, GtkApplier>(
+        factory = {
+            LeafComposeNode(GtkVideo())
+        },
+        update = {
+            set(modifier) { applyModifier(modifier) }
+            set(file) { this.widget.file = it }
+            set(autoplay) { this.widget.autoplay = it }
+            set(graphicsOffload) { this.widget.graphicsOffload = it }
+            set(loop) { this.widget.loop = it }
+        },
+    )
+}

--- a/lib/src/main/kotlin/io/github/compose4gtk/gtk/components/Video.kt
+++ b/lib/src/main/kotlin/io/github/compose4gtk/gtk/components/Video.kt
@@ -40,19 +40,6 @@ sealed interface VideoState {
 }
 
 private class VideoStateImpl : VideoState {
-    private var _duration by mutableLongStateOf(0L)
-    private var _ended by mutableStateOf(false)
-    private var _error by mutableStateOf<GError?>(null)
-    private var _hasAudio by mutableStateOf(false)
-    private var _hasVideo by mutableStateOf(false)
-    private var _loop by mutableStateOf(false)
-    private var _muted by mutableStateOf(false)
-    private var _volume by mutableDoubleStateOf(1.0)
-    private var _playing by mutableStateOf(false)
-    private var _prepared by mutableStateOf(false)
-    private var _seekable by mutableStateOf(true)
-    private var _seeking by mutableStateOf(false)
-    private var _timestamp by mutableLongStateOf(0L)
 
     private var _video by mutableStateOf<GtkVideo?>(null)
     override var video: GtkVideo?
@@ -67,112 +54,115 @@ private class VideoStateImpl : VideoState {
                 val stream = value.mediaStream ?: return@onNotify
 
                 stream.onNotify("duration") { _: ParamSpec? ->
-                    _duration = stream.duration
+                    duration = stream.duration
                 }
 
                 stream.onNotify("ended") { _: ParamSpec? ->
-                    _ended = stream.ended
+                    ended = stream.ended
                 }
 
                 stream.onNotify("error") { _: ParamSpec? ->
-                    _error = stream.error
+                    error = stream.error
                 }
 
                 stream.onNotify("has-audio") { _: ParamSpec? ->
-                    _hasAudio = stream.hasAudio()
+                    hasAudio = stream.hasAudio()
                 }
 
                 stream.onNotify("has-video") { _: ParamSpec? ->
-                    _hasVideo = stream.hasVideo()
+                    hasVideo = stream.hasVideo()
                 }
 
                 stream.onNotify("loop") { _: ParamSpec? ->
-                    _loop = stream.loop
+                    loop = stream.loop
                 }
 
                 stream.onNotify("muted") { _: ParamSpec? ->
-                    _muted = stream.muted
+                    muted = stream.muted
                 }
 
                 stream.onNotify("volume") { _: ParamSpec? ->
                     if (!stream.muted) {
-                        _volume = stream.volume
+                        volume = stream.volume
                     }
                 }
 
                 stream.onNotify("playing") { _: ParamSpec? ->
-                    _playing = stream.playing
+                    playing = stream.playing
                 }
 
                 stream.onNotify("prepared") { _: ParamSpec? ->
-                    _prepared = stream.isPrepared
+                    prepared = stream.isPrepared
                 }
 
                 stream.onNotify("seekable") { _: ParamSpec? ->
-                    _seekable = stream.isSeekable
+                    seekable = stream.isSeekable
                 }
 
                 stream.onNotify("seeking") { _: ParamSpec? ->
-                    _seeking = stream.isSeeking
+                    seeking = stream.isSeeking
                 }
 
                 stream.onNotify("timestamp") { _: ParamSpec? ->
-                    _timestamp = stream.timestamp
+                    timestamp = stream.timestamp
                 }
             }
         }
 
-    override val duration
-        get() = _duration
+    override var duration by mutableLongStateOf(0L)
+        private set
 
-    override val ended
-        get() = _ended
+    override var ended by mutableStateOf(false)
+        private set
 
-    override val error: GError?
-        get() = _error
+    override var error by mutableStateOf<GError?>(null)
+        private set
 
-    override val hasAudio: Boolean
-        get() = _hasAudio
+    override var hasAudio by mutableStateOf(false)
+        private set
 
-    override val hasVideo: Boolean
-        get() = _hasVideo
+    override var hasVideo by mutableStateOf(false)
+        private set
 
-    override var loop: Boolean
+    private var _loop by mutableStateOf(false)
+    override var loop
         get() = _loop
         set(value) {
             _loop = value
             video?.mediaStream?.loop = value
         }
 
-    override var muted: Boolean
+    private var _muted by mutableStateOf(false)
+    override var muted
         get() = _muted
         set(value) {
             _muted = value
             video?.mediaStream?.muted = value
-            video?.mediaStream?.volume = _volume
+            video?.mediaStream?.volume = volume
         }
 
-    override var volume: Double
+    private var _volume by mutableDoubleStateOf(1.0)
+    override var volume
         get() = _volume
         set(value) {
             _volume = value
             video?.mediaStream?.volume = value
         }
 
-    override val playing: Boolean
-        get() = _playing
+    override var playing by mutableStateOf(false)
+        private set
 
-    override val prepared: Boolean
-        get() = _prepared
+    override var prepared by mutableStateOf(false)
+        private set
 
-    override val seekable: Boolean
-        get() = _seekable
+    override var seekable by mutableStateOf(true)
+        private set
 
-    override val seeking: Boolean
-        get() = _seeking
+    override var seeking by mutableStateOf(false)
+        private set
 
-    override val timestamp: Long
-        get() = _timestamp
+    override var timestamp by mutableLongStateOf(0L)
+        private set
 
     override fun play() {
         video?.mediaStream?.play()

--- a/lib/src/main/kotlin/io/github/compose4gtk/gtk/components/Video.kt
+++ b/lib/src/main/kotlin/io/github/compose4gtk/gtk/components/Video.kt
@@ -2,14 +2,253 @@ package io.github.compose4gtk.gtk.components
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.ComposeNode
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableDoubleStateOf
+import androidx.compose.runtime.mutableLongStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import io.github.compose4gtk.GtkApplier
 import io.github.compose4gtk.GtkComposeWidget
 import io.github.compose4gtk.LeafComposeNode
 import io.github.compose4gtk.modifier.Modifier
 import org.gnome.gio.File
+import org.gnome.glib.GError
+import org.gnome.gobject.ParamSpec
 import org.gnome.gtk.GraphicsOffloadEnabled
 import org.gnome.gtk.Video as GtkVideo
 
+sealed interface VideoState {
+    // Modifiable properties
+    val video: GtkVideo?
+    val duration: Long
+    val ended: Boolean
+    val error: GError?
+    val hasAudio: Boolean
+    val hasVideo: Boolean
+    var loop: Boolean
+    var muted: Boolean
+    var volume: Double
+    val playing: Boolean
+    val prepared: Boolean
+    val seekable: Boolean
+    val seeking: Boolean
+    val timestamp: Long
+    fun play()
+    fun pause()
+    fun seek(timestamp: Long)
+}
+
+private class VideoStateImpl : VideoState {
+    private var _duration by mutableLongStateOf(0L)
+    private var _ended by mutableStateOf(false)
+    private var _error by mutableStateOf<GError?>(null)
+    private var _hasAudio by mutableStateOf(false)
+    private var _hasVideo by mutableStateOf(false)
+    private var _loop by mutableStateOf(false)
+    private var _muted by mutableStateOf(false)
+    private var _volume by mutableDoubleStateOf(1.0)
+    private var _playing by mutableStateOf(false)
+    private var _prepared by mutableStateOf(false)
+    private var _seekable by mutableStateOf(true)
+    private var _seeking by mutableStateOf(false)
+    private var _timestamp by mutableLongStateOf(0L)
+
+    private var _video by mutableStateOf<GtkVideo?>(null)
+    override var video: GtkVideo?
+        get() = _video
+        set(value) {
+            check(_video == null) { "VideoState can be associated to a single Video" }
+            requireNotNull(value)
+            _video = value
+
+            // Listen for mediaStream changes
+            value.onNotify("media-stream") { _: ParamSpec? ->
+                val stream = value.mediaStream ?: return@onNotify
+
+                stream.onNotify("duration") { _: ParamSpec? ->
+                    _duration = stream.duration
+                }
+
+                stream.onNotify("ended") { _: ParamSpec? ->
+                    _ended = stream.ended
+                }
+
+                stream.onNotify("error") { _: ParamSpec? ->
+                    _error = stream.error
+                }
+
+                stream.onNotify("has-audio") { _: ParamSpec? ->
+                    _hasAudio = stream.hasAudio()
+                }
+
+                stream.onNotify("has-video") { _: ParamSpec? ->
+                    _hasVideo = stream.hasVideo()
+                }
+
+                stream.onNotify("loop") { _: ParamSpec? ->
+                    _loop = stream.loop
+                }
+
+                stream.onNotify("muted") { _: ParamSpec? ->
+                    _muted = stream.muted
+                }
+
+                stream.onNotify("volume") { _: ParamSpec? ->
+                    if (!stream.muted) {
+                        _volume = stream.volume
+                    }
+                }
+
+                stream.onNotify("playing") { _: ParamSpec? ->
+                    _playing = stream.playing
+                }
+
+                stream.onNotify("prepared") { _: ParamSpec? ->
+                    _prepared = stream.isPrepared
+                }
+
+                stream.onNotify("seekable") { _: ParamSpec? ->
+                    _seekable = stream.isSeekable
+                }
+
+                stream.onNotify("seeking") { _: ParamSpec? ->
+                    _seeking = stream.isSeeking
+                }
+
+                stream.onNotify("timestamp") { _: ParamSpec? ->
+                    _timestamp = stream.timestamp
+                }
+            }
+        }
+
+    override val duration
+        get() = _duration
+
+    override val ended
+        get() = _ended
+
+    override val error: GError?
+        get() = _error
+
+    override val hasAudio: Boolean
+        get() = _hasAudio
+
+    override val hasVideo: Boolean
+        get() = _hasVideo
+
+    override var loop: Boolean
+        get() = _loop
+        set(value) {
+            _loop = value
+            video?.mediaStream?.loop = value
+        }
+
+    override var muted: Boolean
+        get() = _muted
+        set(value) {
+            _muted = value
+            video?.mediaStream?.muted = value
+            video?.mediaStream?.volume = _volume
+        }
+
+    override var volume: Double
+        get() = _volume
+        set(value) {
+            _volume = value
+            video?.mediaStream?.volume = value
+        }
+
+    override val playing: Boolean
+        get() = _playing
+
+    override val prepared: Boolean
+        get() = _prepared
+
+    override val seekable: Boolean
+        get() = _seekable
+
+    override val seeking: Boolean
+        get() = _seeking
+
+    override val timestamp: Long
+        get() = _timestamp
+
+    override fun play() {
+        video?.mediaStream?.play()
+    }
+
+    override fun pause() {
+        video?.mediaStream?.pause()
+    }
+
+    override fun seek(timestamp: Long) {
+        video?.mediaStream?.seek(timestamp)
+    }
+}
+
+@Composable
+fun rememberVideoState(): VideoState {
+    val state = remember { VideoStateImpl() }
+    return state
+}
+
+/**
+ * Creates a [org.gnome.gtk.Video] that displays a video whose stream
+ * is controlled by a [VideoState].
+ *
+ * @param state The [VideoState] that controls the video's media stream.
+ * @param modifier Compose [Modifier] for layout and styling.
+ * @param file The video file.
+ * @param autoplay Whether the video automatically plays once it's loaded.
+ * @param graphicsOffload Offloads the graphics which bypasses gsk rendering
+ * by passing the content of its child directly to the compositor.
+ */
+@Composable
+fun Video(
+    state: VideoState,
+    modifier: Modifier = Modifier,
+    file: File? = null,
+    autoplay: Boolean = false,
+    graphicsOffload: GraphicsOffloadEnabled = GraphicsOffloadEnabled.DISABLED,
+) {
+    val stateImpl: VideoStateImpl = when (state) {
+        is VideoStateImpl -> state
+    }
+
+    // Pause the stream so it does not continue in the background
+    DisposableEffect(Unit) {
+        onDispose {
+            stateImpl.video?.mediaStream?.pause()
+        }
+    }
+
+    ComposeNode<GtkComposeWidget<GtkVideo>, GtkApplier>(
+        factory = {
+            val gObject = GtkVideo()
+            stateImpl.video = gObject
+            LeafComposeNode(gObject)
+        },
+        update = {
+            set(modifier) { applyModifier(modifier) }
+            set(file) { this.widget.file = it }
+            set(autoplay) { this.widget.autoplay = it }
+            set(graphicsOffload) { this.widget.graphicsOffload = it }
+        },
+    )
+}
+
+/**
+ * Creates a [org.gnome.gtk.Video] that displays a video.
+ *
+ * @param modifier Compose [Modifier] for layout and styling.
+ * @param file The video file.
+ * @param autoplay Whether the video automatically plays once it's loaded.
+ * @param graphicsOffload Offloads the graphics which bypasses gsk rendering
+ * by passing the content of its child directly to the compositor.
+ * @param loop Whether the video restarts when it reaches the end.
+ */
 @Composable
 fun Video(
     modifier: Modifier = Modifier,

--- a/lib/src/main/kotlin/io/github/compose4gtk/gtk/components/Video.kt
+++ b/lib/src/main/kotlin/io/github/compose4gtk/gtk/components/Video.kt
@@ -53,6 +53,10 @@ private class VideoStateImpl : VideoState {
             value.onNotify("media-stream") { _: ParamSpec? ->
                 val stream = value.mediaStream ?: return@onNotify
 
+                stream.loop = loop
+                stream.muted = muted
+                stream.volume = volume
+
                 stream.onNotify("duration") { _: ParamSpec? ->
                     duration = stream.duration
                 }
@@ -71,20 +75,6 @@ private class VideoStateImpl : VideoState {
 
                 stream.onNotify("has-video") { _: ParamSpec? ->
                     hasVideo = stream.hasVideo()
-                }
-
-                stream.onNotify("loop") { _: ParamSpec? ->
-                    loop = stream.loop
-                }
-
-                stream.onNotify("muted") { _: ParamSpec? ->
-                    muted = stream.muted
-                }
-
-                stream.onNotify("volume") { _: ParamSpec? ->
-                    if (!stream.muted) {
-                        volume = stream.volume
-                    }
                 }
 
                 stream.onNotify("playing") { _: ParamSpec? ->

--- a/lib/src/main/kotlin/io/github/compose4gtk/gtk/components/Video.kt
+++ b/lib/src/main/kotlin/io/github/compose4gtk/gtk/components/Video.kt
@@ -183,6 +183,27 @@ fun rememberVideoState(): VideoState {
     return state
 }
 
+@Composable
+private fun <V : GtkComposeWidget<GtkVideo>> BaseVideo(
+    creator: () -> V,
+    modifier: Modifier = Modifier,
+    file: File? = null,
+    autoplay: Boolean = false,
+    graphicsOffload: GraphicsOffloadEnabled = GraphicsOffloadEnabled.DISABLED,
+    loop: Boolean = false,
+) {
+    ComposeNode<V, GtkApplier>(
+        factory = creator,
+        update = {
+            set(modifier) { applyModifier(modifier) }
+            set(file) { this.widget.file = it }
+            set(autoplay) { this.widget.autoplay = it }
+            set(graphicsOffload) { this.widget.graphicsOffload = it }
+            set(loop) { this.widget.mediaStream?.loop = it }
+        },
+    )
+}
+
 /**
  * Creates a [org.gnome.gtk.Video] that displays a video whose stream
  * is controlled by a [VideoState].
@@ -213,18 +234,17 @@ fun Video(
         }
     }
 
-    ComposeNode<GtkComposeWidget<GtkVideo>, GtkApplier>(
-        factory = {
+    BaseVideo(
+        creator = {
             val gObject = GtkVideo()
             stateImpl.video = gObject
             LeafComposeNode(gObject)
         },
-        update = {
-            set(modifier) { applyModifier(modifier) }
-            set(file) { this.widget.file = it }
-            set(autoplay) { this.widget.autoplay = it }
-            set(graphicsOffload) { this.widget.graphicsOffload = it }
-        },
+        modifier = modifier,
+        file = file,
+        autoplay = autoplay,
+        graphicsOffload = graphicsOffload,
+        loop = stateImpl.loop,
     )
 }
 
@@ -246,16 +266,14 @@ fun Video(
     graphicsOffload: GraphicsOffloadEnabled = GraphicsOffloadEnabled.DISABLED,
     loop: Boolean = false,
 ) {
-    ComposeNode<GtkComposeWidget<GtkVideo>, GtkApplier>(
-        factory = {
+    BaseVideo(
+        creator = {
             LeafComposeNode(GtkVideo())
         },
-        update = {
-            set(modifier) { applyModifier(modifier) }
-            set(file) { this.widget.file = it }
-            set(autoplay) { this.widget.autoplay = it }
-            set(graphicsOffload) { this.widget.graphicsOffload = it }
-            set(loop) { this.widget.loop = it }
-        },
+        modifier = modifier,
+        file = file,
+        autoplay = autoplay,
+        graphicsOffload = graphicsOffload,
+        loop = loop,
     )
 }

--- a/lib/src/main/kotlin/io/github/compose4gtk/gtk/components/Video.kt
+++ b/lib/src/main/kotlin/io/github/compose4gtk/gtk/components/Video.kt
@@ -20,7 +20,6 @@ import org.gnome.gtk.GraphicsOffloadEnabled
 import org.gnome.gtk.Video as GtkVideo
 
 sealed interface VideoState {
-    // Modifiable properties
     val video: GtkVideo?
     val duration: Long
     val ended: Boolean

--- a/lib/src/test/kotlin/Video.kt
+++ b/lib/src/test/kotlin/Video.kt
@@ -56,7 +56,20 @@ fun main(args: Array<String>) {
         ) {
             val window = LocalApplicationWindow.current
 
+            fun getFile(callback: (File?) -> Unit) {
+                fileDialog.open(window, null) { _: GObject?, result, _: MemorySegment? ->
+                    val file = try {
+                        fileDialog.openFinish(result)
+                    } catch (_: Throwable) {
+                        null
+                    }
+                    callback(file)
+                }
+            }
+
             var selectedFile by remember { mutableStateOf<File?>(null) }
+
+            var useBasicVideoPlayer by remember { mutableStateOf(false) }
 
             ToolbarView(
                 topBar = {
@@ -75,49 +88,73 @@ fun main(args: Array<String>) {
                             title = "Video",
                             description = "Select a video file",
                         ) {
-                            Button(
-                                label = "Open…",
-                                onClick = {
-                                    fileDialog.open(
-                                        window,
-                                        null,
-                                    ) { _: GObject?, result, _: MemorySegment? ->
-                                        var file: File? = null
-                                        try {
-                                            file = fileDialog.openFinish(result)
-                                        } catch (_: Throwable) {
+                            VerticalBox(spacing = 8) {
+                                Button(
+                                    label = "Open…",
+                                    onClick = {
+                                        getFile {
+                                            selectedFile = it
                                         }
-                                        if (file == null) return@open
-                                        selectedFile = file
-                                    }
-                                },
-                                modifier = Modifier.cssClasses("pill", "suggested-action"),
-                            )
+                                        useBasicVideoPlayer = false
+                                    },
+                                    modifier = Modifier.cssClasses("pill", "suggested-action"),
+                                )
+                                Button(
+                                    label = "Open… (basic video player)",
+                                    onClick = {
+                                        getFile {
+                                            selectedFile = it
+                                        }
+                                        useBasicVideoPlayer = true
+                                    },
+                                    modifier = Modifier.cssClasses("pill", "suggested-action"),
+                                )
+                            }
                         }
                     } else {
-                        val videoState = rememberVideoState()
-                        ScrolledWindow(
-                            modifier = Modifier.expand(),
-                            propagateNaturalWidth = true,
-                            propagateNaturalHeight = true,
-                        ) {
-                            VerticalBox(
-                                modifier = Modifier.margin(8),
-                                spacing = 8,
-                            ) {
-                                Video(
-                                    state = videoState,
-                                    file = selectedFile,
-                                    modifier = Modifier.sizeRequest(-1, 300),
+                        if (useBasicVideoPlayer) {
+                            VerticalBox(spacing = 8) {
+                                var loop by remember { mutableStateOf(false) }
+
+                                Video(file = selectedFile, loop = loop)
+                                ToggleButton(
+                                    label = "Loop",
+                                    active = loop,
+                                    onToggle = { loop = !loop },
                                 )
-                                MediaControls(videoState)
-                                StreamInfo(videoState)
-                                StreamControls(videoState)
                                 Button(
                                     label = "Remove video",
                                     onClick = { selectedFile = null },
                                     modifier = Modifier.cssClasses("destructive-action").expand(false),
                                 )
+                            }
+                        } else {
+                            val videoState = rememberVideoState().apply {
+                                loop = true
+                            }
+                            ScrolledWindow(
+                                modifier = Modifier.expand(),
+                                propagateNaturalWidth = true,
+                                propagateNaturalHeight = true,
+                            ) {
+                                VerticalBox(
+                                    modifier = Modifier.margin(8),
+                                    spacing = 8,
+                                ) {
+                                    Video(
+                                        state = videoState,
+                                        file = selectedFile,
+                                        modifier = Modifier.sizeRequest(-1, 300),
+                                    )
+                                    MediaControls(videoState)
+                                    StreamInfo(videoState)
+                                    StreamControls(videoState)
+                                    Button(
+                                        label = "Remove video",
+                                        onClick = { selectedFile = null },
+                                        modifier = Modifier.cssClasses("destructive-action").expand(false),
+                                    )
+                                }
                             }
                         }
                     }

--- a/lib/src/test/kotlin/Video.kt
+++ b/lib/src/test/kotlin/Video.kt
@@ -1,19 +1,32 @@
+import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import io.github.compose4gtk.adw.adwApplication
+import io.github.compose4gtk.adw.components.ActionRow
 import io.github.compose4gtk.adw.components.ApplicationWindow
+import io.github.compose4gtk.adw.components.ExpanderRow
 import io.github.compose4gtk.adw.components.HeaderBar
+import io.github.compose4gtk.adw.components.StatusPage
 import io.github.compose4gtk.adw.components.ToolbarView
 import io.github.compose4gtk.gtk.components.Button
+import io.github.compose4gtk.gtk.components.HorizontalBox
+import io.github.compose4gtk.gtk.components.Label
+import io.github.compose4gtk.gtk.components.ListBox
+import io.github.compose4gtk.gtk.components.MediaControls
+import io.github.compose4gtk.gtk.components.ScrolledWindow
+import io.github.compose4gtk.gtk.components.ToggleButton
 import io.github.compose4gtk.gtk.components.VerticalBox
 import io.github.compose4gtk.gtk.components.Video
+import io.github.compose4gtk.gtk.components.VideoState
+import io.github.compose4gtk.gtk.components.rememberVideoState
 import io.github.compose4gtk.modifier.Modifier
 import io.github.compose4gtk.modifier.cssClasses
 import io.github.compose4gtk.modifier.expand
 import io.github.compose4gtk.modifier.horizontalAlignment
 import io.github.compose4gtk.modifier.margin
+import io.github.compose4gtk.modifier.sizeRequest
 import io.github.compose4gtk.modifier.verticalAlignment
 import io.github.compose4gtk.shared.components.LocalApplicationWindow
 import org.gnome.gio.File
@@ -22,6 +35,7 @@ import org.gnome.gobject.GObject
 import org.gnome.gtk.Align
 import org.gnome.gtk.FileDialog
 import org.gnome.gtk.FileFilter
+import org.gnome.gtk.SelectionMode
 import java.lang.foreign.MemorySegment
 
 val filter: FileFilter = FileFilter.builder().setName("Video files").setMimeTypes(arrayOf("video/mp4")).build()
@@ -37,8 +51,8 @@ fun main(args: Array<String>) {
         ApplicationWindow(
             title = "Video",
             onClose = ::exitApplication,
-            defaultHeight = 600,
-            defaultWidth = 800,
+            defaultHeight = 800,
+            defaultWidth = 1200,
         ) {
             val window = LocalApplicationWindow.current
 
@@ -50,33 +64,144 @@ fun main(args: Array<String>) {
                 },
             ) {
                 VerticalBox(
-                    modifier = Modifier.expand().horizontalAlignment(Align.CENTER).verticalAlignment(Align.CENTER)
+                    modifier = Modifier
+                        .expand()
+                        .horizontalAlignment(Align.CENTER)
+                        .verticalAlignment(Align.CENTER)
                         .margin(8),
                 ) {
                     if (selectedFile == null) {
-                        Button(
-                            label = "Open…",
-                            onClick = {
-                                fileDialog.open(
-                                    window,
-                                    null,
-                                ) { _: GObject?, result, _: MemorySegment? ->
-                                    var file: File? = null
-                                    try {
-                                        file = fileDialog.openFinish(result)
-                                    } catch (_: Throwable) {
+                        StatusPage(
+                            title = "Video",
+                            description = "Select a video file",
+                        ) {
+                            Button(
+                                label = "Open…",
+                                onClick = {
+                                    fileDialog.open(
+                                        window,
+                                        null,
+                                    ) { _: GObject?, result, _: MemorySegment? ->
+                                        var file: File? = null
+                                        try {
+                                            file = fileDialog.openFinish(result)
+                                        } catch (_: Throwable) {
+                                        }
+                                        if (file == null) return@open
+                                        selectedFile = file
                                     }
-                                    if (file == null) return@open
-                                    selectedFile = file
-                                }
-                            },
-                            modifier = Modifier.cssClasses("pill", "suggested-action"),
-                        )
+                                },
+                                modifier = Modifier.cssClasses("pill", "suggested-action"),
+                            )
+                        }
                     } else {
-                        Video(file = selectedFile)
+                        val videoState = rememberVideoState()
+                        ScrolledWindow(
+                            modifier = Modifier.expand(),
+                            propagateNaturalWidth = true,
+                            propagateNaturalHeight = true,
+                        ) {
+                            VerticalBox(
+                                modifier = Modifier.margin(8),
+                                spacing = 8,
+                            ) {
+                                Video(
+                                    state = videoState,
+                                    file = selectedFile,
+                                    modifier = Modifier.sizeRequest(-1, 300),
+                                )
+                                MediaControls(videoState)
+                                StreamInfo(videoState)
+                                StreamControls(videoState)
+                                Button(
+                                    label = "Remove video",
+                                    onClick = { selectedFile = null },
+                                    modifier = Modifier.cssClasses("destructive-action").expand(false),
+                                )
+                            }
+                        }
                     }
                 }
             }
         }
     }
+}
+
+@Composable
+fun StreamInfo(videoState: VideoState, modifier: Modifier = Modifier) {
+    var expanded by remember { mutableStateOf(false) }
+
+    ListBox(
+        modifier = modifier.cssClasses("boxed-list"),
+        selectionMode = SelectionMode.NONE,
+    ) {
+        ExpanderRow(expanded = expanded, title = "Stream info", onExpand = { expanded = !expanded }) {
+            ActionRow(title = "Duration: ${videoState.duration}")
+            ActionRow(title = "Ended: ${videoState.ended}")
+            ActionRow(
+                title = "Error: ${videoState.error?.readMessage() ?: "no errors"}",
+                modifier = Modifier.cssClasses(
+                    if (videoState.error != null) listOf("error") else emptyList(),
+                ),
+            )
+            ActionRow(title = "Has audio: ${videoState.hasAudio}")
+            ActionRow(title = "Has video: ${videoState.hasVideo}")
+            ActionRow(title = "Loop: ${videoState.loop}")
+            ActionRow(title = "Muted: ${videoState.muted}")
+            ActionRow(title = "Volume: %.1f".format(videoState.volume))
+            ActionRow(title = "Playing: ${videoState.playing}")
+            ActionRow(title = "Prepared: ${videoState.prepared}")
+            ActionRow(title = "Seekable: ${videoState.seekable}")
+            ActionRow(title = "Seeking: ${videoState.seeking}")
+            ActionRow(title = "Timestamp: ${videoState.timestamp}")
+        }
+    }
+}
+
+@Composable
+fun StreamControls(videoState: VideoState, modifier: Modifier = Modifier) {
+    VerticalBox(modifier = modifier) {
+        Label(text = "Play control")
+        HorizontalBox(
+            modifier = Modifier.expand(),
+            spacing = 8,
+            homogeneous = true,
+        ) {
+            Button(label = "Play", onClick = { videoState.play() })
+            Button(label = "Pause", onClick = { videoState.pause() })
+        }
+    }
+    VerticalBox {
+        Label(text = "Volume control")
+        HorizontalBox(
+            modifier = Modifier.expand(),
+            spacing = 8,
+            homogeneous = true,
+        ) {
+            Button(
+                label = "Down",
+                onClick = {
+                    val currentVolume = videoState.volume
+                    videoState.volume = (currentVolume - 0.1).coerceIn(0.0, 1.0)
+                },
+            )
+            Button(
+                label = "Up",
+                onClick = {
+                    val currentVolume = videoState.volume
+                    videoState.volume = (currentVolume + 0.1).coerceIn(0.0, 1.0)
+                },
+            )
+        }
+    }
+    ToggleButton(
+        label = "Loop",
+        active = videoState.loop,
+        onToggle = { videoState.loop = !videoState.loop },
+    )
+    ToggleButton(
+        label = "Mute",
+        active = videoState.muted,
+        onToggle = { videoState.muted = !videoState.muted },
+    )
 }

--- a/lib/src/test/kotlin/Video.kt
+++ b/lib/src/test/kotlin/Video.kt
@@ -38,7 +38,7 @@ import org.gnome.gtk.FileFilter
 import org.gnome.gtk.SelectionMode
 import java.lang.foreign.MemorySegment
 
-val filter: FileFilter = FileFilter.builder().setName("Video files").setMimeTypes(arrayOf("video/mp4")).build()
+val filter: FileFilter = FileFilter.builder().setName("Video files").setMimeTypes(arrayOf("video/*")).build()
 
 val filters = ListStore<FileFilter>().apply {
     append(filter)

--- a/lib/src/test/kotlin/Video.kt
+++ b/lib/src/test/kotlin/Video.kt
@@ -1,0 +1,82 @@
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import io.github.compose4gtk.adw.adwApplication
+import io.github.compose4gtk.adw.components.ApplicationWindow
+import io.github.compose4gtk.adw.components.HeaderBar
+import io.github.compose4gtk.adw.components.ToolbarView
+import io.github.compose4gtk.gtk.components.Button
+import io.github.compose4gtk.gtk.components.VerticalBox
+import io.github.compose4gtk.gtk.components.Video
+import io.github.compose4gtk.modifier.Modifier
+import io.github.compose4gtk.modifier.cssClasses
+import io.github.compose4gtk.modifier.expand
+import io.github.compose4gtk.modifier.horizontalAlignment
+import io.github.compose4gtk.modifier.margin
+import io.github.compose4gtk.modifier.verticalAlignment
+import io.github.compose4gtk.shared.components.LocalApplicationWindow
+import org.gnome.gio.File
+import org.gnome.gio.ListStore
+import org.gnome.gobject.GObject
+import org.gnome.gtk.Align
+import org.gnome.gtk.FileDialog
+import org.gnome.gtk.FileFilter
+import java.lang.foreign.MemorySegment
+
+val filter: FileFilter = FileFilter.builder().setName("Video files").setMimeTypes(arrayOf("video/mp4")).build()
+
+val filters = ListStore<FileFilter>().apply {
+    append(filter)
+}
+
+val fileDialog: FileDialog = FileDialog.builder().setFilters(filters).build()
+
+fun main(args: Array<String>) {
+    adwApplication("my.example.hello-app", args) {
+        ApplicationWindow(
+            title = "Video",
+            onClose = ::exitApplication,
+            defaultHeight = 600,
+            defaultWidth = 800,
+        ) {
+            val window = LocalApplicationWindow.current
+
+            var selectedFile by remember { mutableStateOf<File?>(null) }
+
+            ToolbarView(
+                topBar = {
+                    HeaderBar()
+                },
+            ) {
+                VerticalBox(
+                    modifier = Modifier.expand().horizontalAlignment(Align.CENTER).verticalAlignment(Align.CENTER)
+                        .margin(8),
+                ) {
+                    if (selectedFile == null) {
+                        Button(
+                            label = "Open…",
+                            onClick = {
+                                fileDialog.open(
+                                    window,
+                                    null,
+                                ) { _: GObject?, result, _: MemorySegment? ->
+                                    var file: File? = null
+                                    try {
+                                        file = fileDialog.openFinish(result)
+                                    } catch (_: Throwable) {
+                                    }
+                                    if (file == null) return@open
+                                    selectedFile = file
+                                }
+                            },
+                            modifier = Modifier.cssClasses("pill", "suggested-action"),
+                        )
+                    } else {
+                        Video(file = selectedFile)
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds the Video widget. One component takes only a file and has the basic functionalities without creating a VideoState for the media stream. The other component takes a VideoState that can manage the media stream for more control. The MediaControls components than uses that VideoState.


https://github.com/user-attachments/assets/1d429463-435d-4514-92ee-01b7a6aaf52e

The screen capture in Gnome doesn't record audio for some reason but the audio does work.