### PR TITLE
Make GtkApplier public

### DIFF
--- a/lib/src/main/kotlin/io/github/compose4gtk/GtkApplier.kt
+++ b/lib/src/main/kotlin/io/github/compose4gtk/GtkApplier.kt
@@ -2,7 +2,7 @@ package io.github.compose4gtk
 
 import androidx.compose.runtime.AbstractApplier
 
-internal class GtkApplier(root: GtkComposeNode) : AbstractApplier<GtkComposeNode>(root) {
+class GtkApplier(root: GtkComposeNode) : AbstractApplier<GtkComposeNode>(root) {
     override fun insertBottomUp(index: Int, instance: GtkComposeNode) = Unit
     override fun insertTopDown(index: Int, instance: GtkComposeNode) {
         current.addNode(index, instance)


### PR DESCRIPTION
Makes GtkApplier public so users can make their own components. Forgot to make it public with my last PR.